### PR TITLE
Hide license column on sbt 1.3.x

### DIFF
--- a/src/main/scala/com/lightbend/paradox/dependencies/ParadoxDependenciesPlugin.scala
+++ b/src/main/scala/com/lightbend/paradox/dependencies/ParadoxDependenciesPlugin.scala
@@ -34,6 +34,9 @@ object ParadoxDependenciesPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = dependenciesSettings(Compile)
 
   def dependenciesZeroSettings: Seq[Setting[_]] = Seq(
+    paradoxDependenciesShowLicenses := {
+      sbtVersion.value.startsWith("1.1.") || sbtVersion.value.startsWith("1.2.")
+    },
     paradoxDependenciesModuleTrees := Def.taskDyn {
           val projectsToFilter = paradoxDependenciesProjects.?.value
             .map(inProjects)
@@ -54,7 +57,7 @@ object ParadoxDependenciesPlugin extends AutoPlugin {
             val trees = paradoxDependenciesModuleTrees.value
             Seq(
               { _: Writer.Context ⇒
-                new DependenciesDirective(projectId => {
+                new DependenciesDirective(paradoxDependenciesShowLicenses.value)(projectId => {
                   trees.get(projectId) match {
                     case Some(deps) => deps
                     case _ => throw new Error(s"Could not retrieve dependency information for project [$projectId]")

--- a/src/main/scala/com/lightbend/paradox/dependencies/ParadoxDependenciesPluginKeys.scala
+++ b/src/main/scala/com/lightbend/paradox/dependencies/ParadoxDependenciesPluginKeys.scala
@@ -21,6 +21,8 @@ import net.virtualvoid.sbt.graph.ModuleTree
 import sbt._
 
 trait ParadoxDependenciesPluginKeys {
-  val paradoxDependenciesProjects    = settingKey[Seq[ProjectReference]]("Projects to get the dependency information for")
+  val paradoxDependenciesProjects = settingKey[Seq[ProjectReference]]("Projects to get the dependency information for")
+  val paradoxDependenciesShowLicenses =
+    settingKey[Boolean]("Show the license column (license information is unavailable with sbt 1.3.2)")
   val paradoxDependenciesModuleTrees = taskKey[Map[String, ModuleTree]]("Retrieved module trees")
 }


### PR DESCRIPTION
Don't print the license column as since sbt 1.3 the license information is not available via sbt-dependency-graph.

See https://github.com/jrudolph/sbt-dependency-graph/issues/178 for other issues with sbt 1.3.x