### PR TITLE
Replace scalafmtOnCompile with github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Scalafmt
+
+on:
+  pull_request:
+    branches: ['**']
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Code is formatted
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v1
+        with:
+          version: '3.4.3'

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ organizationName := "Lightbend Inc."
 startYear        := Some(2018)
 
 enablePlugins(AutomateHeaderPlugin)
-scalafmtOnCompile := true
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches :=


### PR DESCRIPTION
Replaces `scalafmtOnCompile` with a scalafmt-native github action that checks entire codebase is formatted on PR.