### PR TITLE
Replace Bintray/Travis badges with Maven/Github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sbt-paradox-dependencies [![bintray-badge][]][bintray] [![travis-badge][]][travis]
+# sbt-paradox-dependencies [![maven-central-badge][]][maven-central][![github-actions-badge][]][github-actions]
 
 A [Paradox](https://github.com/lightbend/paradox/) directive to show module's transitive dependencies in the Paradox generated documentation.
 
@@ -31,8 +31,8 @@ The license is Apache 2.0, see LICENSE.
 
 Feel free to ping contributors for code review or discussions. Pull requests are very welcome–thanks in advance!
 
-[bintray]:               https://bintray.com/sbt/sbt-plugin-releases/sbt-paradox-dependencies
-[bintray-badge]:         https://api.bintray.com/packages/sbt/sbt-plugin-releases/sbt-paradox-dependencies/images/download.svg
-[travis]:                https://travis-ci.com/lightbend/sbt-paradox-dependencies
-[travis-badge]:          https://travis-ci.com/lightbend/sbt-paradox-dependencies.svg?branch=master
+[maven-central]:         https://maven-badges.herokuapp.com/maven-central/com.lightbend.paradox/sbt-paradox-dependencies
+[maven-central-badge]:   https://maven-badges.herokuapp.com/maven-central/com.lightbend.paradox/sbt-paradox-dependencies/badge.svg
+[github-actions]:        https://github.com/lightbend/sbt-paradox-dependencies/actions/workflows/ci.yml?query=branch%3Amaster
+[github-actions-badge]:  https://github.com/lightbend/sbt-paradox-dependencies/actions/workflows/ci.yml/badge.svg?branch=master
 


### PR DESCRIPTION
Replaces the badges so that we refer to maven/github actions rather than bintray/travis.

Note that the badges for github actions don't seem to be working but this is a problem with github's API, see https://github.community/t/bug-github-api-list-workflow-runs-returns-0-runs-even-though-there-are-runs/165080/12 for more info. Even if you go onto the github actions badge link manually you get this error in the github UI

![image](https://user-images.githubusercontent.com/2337269/163182668-18b85835-6c8a-474c-ae38-d52fe6fd4e4c.png)
