### PR TITLE
fix: break infinite recursion in renderTreeNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp
 
 ### Scala template
 *.class

--- a/src/main/scala/com/lightbend/paradox/dependencies/DependenciesDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/dependencies/DependenciesDirective.scala
@@ -83,8 +83,9 @@ class DependenciesDirective(showLicenses: Boolean)(projectIdToDependencies: Stri
     p.print("</pre></dd>").println()
   }
 
-  private def renderTreeNode(p: Printer, graph: ModuleGraph, n: Module): Unit =
-    if (n.evictedByVersion.isEmpty) {
+  private def renderTreeNode(p: Printer, graph: ModuleGraph, n: Module): Unit = {
+    // not useful with too many indents and that may be infinite recursion
+    if (p.indent < 100 && n.evictedByVersion.isEmpty) {
       val moduleId = n.id
       val name     = moduleId.name
       p.println()
@@ -103,6 +104,7 @@ class DependenciesDirective(showLicenses: Boolean)(projectIdToDependencies: Stri
         p.indent(-4)
       }
     }
+  }
 
   private def children(graph: ModuleGraph, module: Module) = graph.dependencyMap(module.id)
 

--- a/src/sbt-test/dependencies/happy-path/build.sbt
+++ b/src/sbt-test/dependencies/happy-path/build.sbt
@@ -1,4 +1,6 @@
 enablePlugins(ParadoxPlugin)
 paradoxTheme := None
 
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.17"
+//libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.17"
+
+libraryDependencies += "io.grpc" % "grpc-core" % "1.58.0"


### PR DESCRIPTION
* can be reproduced with libraryDependencies += "io.grpc" % "grpc-core" % "1.58.0"
* normal dependencyTree looks good, so I don't know what is wrong with the grpc dependency or if there is something else missing in this traversal?
