### PR TITLE
Upgrade dependencies to avoid repo.scala-sbt.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15]
+        scala: [2.12.18]
         java: [temurin@8, temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15]
+        scala: [2.12.18]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -129,12 +129,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.15)
+      - name: Download target directories (2.12.18)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.12.15-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.18-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.15)
+      - name: Inflate target directories (2.12.18)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.15"
+ThisBuild / scalaVersion := "2.12.18"
 
 sbtPlugin := true
 
@@ -13,7 +13,7 @@ crossSbtVersions := List("1.1.0")
 organization     := "com.lightbend.paradox"
 name             := "sbt-paradox-dependencies"
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"          % "0.4.3")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"          % "0.10.6")
 addSbtPlugin("net.virtual-void"      % "sbt-dependency-graph" % "0.10.0-RC1")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")
 addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.14.2")
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.10")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.12")

--- a/src/sbt-test/dependencies/happy-path/project/build.properties
+++ b/src/sbt-test/dependencies/happy-path/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.9.7

--- a/src/sbt-test/dependencies/multi-module/project/build.properties
+++ b/src/sbt-test/dependencies/multi-module/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.9.7

--- a/src/sbt-test/dependencies/no-dependencies/project/build.properties
+++ b/src/sbt-test/dependencies/no-dependencies/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.9.7


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`. 